### PR TITLE
Explicitly call out set/get in Usage example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,26 +22,32 @@ Flash messages are stored in the session.  First, setup sessions as usual by
 enabling `cookieParser` and `session` middleware.  Then, use `flash` middleware
 provided by connect-flash.
 
-    var flash = require('connect-flash');
-    var app = express();
+```javascript
+var flash = require('connect-flash');
+var app = express();
 
-    app.configure(function() {
-      app.use(express.cookieParser('keyboard cat'));
-      app.use(express.session({ cookie: { maxAge: 60000 }}));
-      app.use(flash());
-    });
+app.configure(function() {
+  app.use(express.cookieParser('keyboard cat'));
+  app.use(express.session({ cookie: { maxAge: 60000 }}));
+  app.use(flash());
+});
+```
 
-With `flash` middleware in place, all requests will have `req.flash()` function
+With the `flash` middleware in place, all requests will have a `req.flash()` function
 that can be used for flash messages.
 
-    app.get('/flash', function(req, res){
-      req.flash('info', 'Flash is back!')
-      res.redirect('/');
-    });
+```javascript
+app.get('/flash', function(req, res){
+  // Set a flash message by passing the key, followed by the value, to req.flash().
+  req.flash('info', 'Flash is back!')
+  res.redirect('/');
+});
 
-    app.get('/', function(req, res){
-      res.render('index', { message: req.flash('info') });
-    });
+app.get('/', function(req, res){
+  // Get a flash message by passing the key to req.flash()
+  res.render('index', { message: req.flash('info') });
+});
+```
 
 ## Examples
 


### PR DESCRIPTION
I've heard from a few students that the docs for connect-flash didn't call out the getter/setter as much as  they ought to, so I added a couple of comments to the set and get lines in the Usage section of README.md to make it clearer for future noders. I also added syntax highlighting because, well, I like syntax highlighting.

If the comments make sense, I'd appreciate a pull.
