### PR TITLE
Update deprecated license(s) value

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,7 @@
     "email": "jaredhanson@gmail.com",
     "url": "http://www.jaredhanson.net/"
   },
-  "licenses": [ {
-    "type": "MIT",
-    "url": "http://www.opensource.org/licenses/MIT" 
-  } ],
+  "license": "MIT",
   "main": "./lib",
   "dependencies": {
   },


### PR DESCRIPTION
https://docs.npmjs.com/files/package.json#license

Now when installing:
```
npm info package.json connect-flash@0.1.1 No license field.
```