### PR TITLE
Fix crash empty array on empty type

### DIFF
--- a/lib/flash.js
+++ b/lib/flash.js
@@ -68,7 +68,7 @@ function _flash(type, msg) {
       msg.forEach(function(val){
         (msgs[type] = msgs[type] || []).push(val);
       });
-      return msgs[type].length;
+      return (msgs[type] = msgs[type] || []).length;
     }
     return (msgs[type] = msgs[type] || []).push(msg);
   } else if (type) {


### PR DESCRIPTION
This will fix when attempting to add an empty array to a non previous existing type.

Example to reproduce bug:

``` js
function(req, res, next) {
  var errors = req.flash('error');
  req.flash('error', errors); //Here will crash because of the length property of undefined.
}
```
