### PR TITLE
Update flash.js to fix:DeprecationWarning: The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.

### DIFF
--- a/lib/flash.js
+++ b/lib/flash.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 var format = require('util').format;
-var isArray = require('util').isArray;
 
 
 /**
@@ -64,7 +63,7 @@ function _flash(type, msg) {
     if (arguments.length > 2 && format) {
       var args = Array.prototype.slice.call(arguments, 1);
       msg = format.apply(undefined, args);
-    } else if (isArray(msg)) {
+    } else if (Array.isArray(msg)) {
       msg.forEach(function(val){
         (msgs[type] = msgs[type] || []).push(val);
       });


### PR DESCRIPTION
Fix: DeprecationWarning: The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.

Since modifying files in node_modules will be overwritten when you run npm install, use patch-package to persist these changes.
1. npm install patch-package postinstall-postinstall
2. Modify flash.js
3. npx patch-package connect-flash
4. Add the following script to your package.json to ensure the patch is applied after each npm install: "scripts": {
  "postinstall": "patch-package"
}