### PR TITLE
Use Array.isArray instead of util.isArray in flash.js

### DIFF
--- a/lib/flash.js
+++ b/lib/flash.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 var format = require('util').format;
-var isArray = require('util').isArray;
 
 
 /**
@@ -64,7 +63,7 @@ function _flash(type, msg) {
     if (arguments.length > 2 && format) {
       var args = Array.prototype.slice.call(arguments, 1);
       msg = format.apply(undefined, args);
-    } else if (isArray(msg)) {
+    } else if (Array.isArray(msg)) {
       msg.forEach(function(val){
         (msgs[type] = msgs[type] || []).push(val);
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,49 @@
+{
+  "name": "connect-flash",
+  "version": "0.1.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "connect-flash",
+      "version": "0.1.1",
+      "devDependencies": {
+        "vows": "0.6.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.8.tgz",
+      "integrity": "sha512-1zEb73vemXFpUmfh3fsta4YHz3lwebxXvaWmPbFv9apujQBWDnkrPDLXLQs1gZo4RCWMDsT89r0Pf/z8/02TGA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "dev": true,
+      "engines": {
+        "node": "> 0.1.90"
+      }
+    },
+    "node_modules/vows": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/vows/-/vows-0.6.4.tgz",
+      "integrity": "sha512-CnnxhTuz08RHlAEagUSH6806IMxlOvYK5Nz5CyRGaqk9m2qVsP/0vtNBtU9rUS0TTrx3JYmPtHwIELaf+91t0Q==",
+      "dev": true,
+      "dependencies": {
+        "diff": "~1.0.3",
+        "eyes": ">=0.1.6"
+      },
+      "bin": {
+        "vows": "bin/vows"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR addresses the [DEP0044] DeprecationWarning in Node.js, which suggests replacing the deprecated `util.isArray` with `Array.isArray()`.  (below)

`(node:38224) [DEP0044] DeprecationWarning: The util.isArrayAPI is deprecated. Please useArray.isArray() instead.`

Needed to install `diff@latest` and `vows@latest` for `npm test` to pass.