### PR TITLE
Refactor: Replace deprecated 'util'.isArray() with Array.isArray()

### DIFF
--- a/lib/flash.js
+++ b/lib/flash.js
@@ -2,8 +2,6 @@
  * Module dependencies.
  */
 var format = require('util').format;
-var isArray = require('util').isArray;
-
 
 /**
  * Expose `flash()` function on requests.
@@ -64,7 +62,7 @@ function _flash(type, msg) {
     if (arguments.length > 2 && format) {
       var args = Array.prototype.slice.call(arguments, 1);
       msg = format.apply(undefined, args);
-    } else if (isArray(msg)) {
+    } else if (Array.isArray(msg)) {
       msg.forEach(function(val){
         (msgs[type] = msgs[type] || []).push(val);
       });


### PR DESCRIPTION
This PR refactors the code by replacing the deprecated isArray() method from the util module with the modern Array.isArray() method. The util.isArray() method is deprecated and should be avoided in favor of the native Array.isArray(), which is more widely supported and future-proof. The change removes the import of isArray and replaces all occurrences with Array.isArray(). No functional changes were made.