### PR TITLE
update flash.js

### DIFF
--- a/lib/flash.js
+++ b/lib/flash.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 var format = require('util').format;
-var isArray = require('util').isArray;
+var isArray = Array.isArray;
 
 
 /**


### PR DESCRIPTION
Causing warning : (node:9160) [DEP0044] DeprecationWarning: The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.    (Use `node --trace-deprecation ...` to show where the warning was created)