### PR TITLE
Replace deprecated util.isArray() with Array.isArray()

### DIFF
--- a/lib/flash.js
+++ b/lib/flash.js
@@ -1,9 +1,7 @@
 /**
  * Module dependencies.
  */
-var format = require('util').format;
-var isArray = require('util').isArray;
-
+var format = require("util").format;
 
 /**
  * Expose `flash()` function on requests.
@@ -13,14 +11,16 @@ var isArray = require('util').isArray;
  */
 module.exports = function flash(options) {
   options = options || {};
-  var safe = (options.unsafe === undefined) ? true : !options.unsafe;
-  
-  return function(req, res, next) {
-    if (req.flash && safe) { return next(); }
+  var safe = options.unsafe === undefined ? true : !options.unsafe;
+
+  return function (req, res, next) {
+    if (req.flash && safe) {
+      return next();
+    }
     req.flash = _flash;
     next();
-  }
-}
+  };
+};
 
 /**
  * Queue flash `msg` of the given `type`.
@@ -57,15 +57,15 @@ module.exports = function flash(options) {
  * @api public
  */
 function _flash(type, msg) {
-  if (this.session === undefined) throw Error('req.flash() requires sessions');
-  var msgs = this.session.flash = this.session.flash || {};
+  if (this.session === undefined) throw Error("req.flash() requires sessions");
+  var msgs = (this.session.flash = this.session.flash || {});
   if (type && msg) {
     // util.format is available in Node.js 0.6+
     if (arguments.length > 2 && format) {
       var args = Array.prototype.slice.call(arguments, 1);
       msg = format.apply(undefined, args);
-    } else if (isArray(msg)) {
-      msg.forEach(function(val){
+    } else if (Array.isArray(msg)) {
+      msg.forEach(function (val) {
         (msgs[type] = msgs[type] || []).push(val);
       });
       return msgs[type].length;

--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
-  "name": "connect-flash",
+  "name": "connect-flash-modern",
   "version": "0.1.1",
   "description": "Flash message middleware for Connect.",
-  "keywords": ["connect", "express", "flash", "messages"],
+  "keywords": [
+    "connect",
+    "express",
+    "flash",
+    "messages"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/jaredhanson/connect-flash.git"
@@ -15,18 +20,21 @@
     "email": "jaredhanson@gmail.com",
     "url": "http://www.jaredhanson.net/"
   },
-  "licenses": [ {
-    "type": "MIT",
-    "url": "http://www.opensource.org/licenses/MIT" 
-  } ],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/MIT"
+    }
+  ],
   "main": "./lib",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "vows": "0.6.x"
   },
   "scripts": {
     "test": "NODE_PATH=lib node_modules/.bin/vows test/*-test.js"
   },
-  "engines": { "node": ">= 0.4.0" }
+  "engines": {
+    "node": ">= 0.4.0"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "connect-flash-modern",
+  "name": "connect-flash",
   "version": "0.1.1",
   "description": "Flash message middleware for Connect.",
   "keywords": [


### PR DESCRIPTION
This pull request fixes a Node.js deprecation warning caused by the use of `util.isArray()` in `lib/flash.js`.

**Changes made:**
- Removed `var isArray = require('util').isArray;`
- Replaced all instances of `isArray(msg)` with `Array.isArray(msg)`

**Reason for change:**
Node.js has deprecated `util.isArray()`. Using `Array.isArray()` is the recommended modern approach and removes the warning when using `connect-flash` in current Node.js versions.

**Testing:**
- Tested locally by replacing `connect-flash` in a sample project with this patched version.
- Verified that all flash functionalities work as expected.
- No deprecation warnings appear.

This patch is backward-compatible and does not affect existing API behavior.
