### PR TITLE
Replace isArray with Array.isArray

### DIFF
--- a/lib/flash.js
+++ b/lib/flash.js
@@ -2,7 +2,7 @@
  * Module dependencies.
  */
 var format = require('util').format;
-var isArray = require('util').isArray;
+//var isArray = require('util').isArray;
 
 
 /**
@@ -64,7 +64,7 @@ function _flash(type, msg) {
     if (arguments.length > 2 && format) {
       var args = Array.prototype.slice.call(arguments, 1);
       msg = format.apply(undefined, args);
-    } else if (isArray(msg)) {
+    } else if (Array.isArray(msg)) {
       msg.forEach(function(val){
         (msgs[type] = msgs[type] || []).push(val);
       });


### PR DESCRIPTION
util.isArray() was part of Node’s util module long ago.
It’s now deprecated, meaning it still works but is discouraged and may be removed in future Node versions.