### PR TITLE
Fix (DEP0044): Replace util.isArray with Array.isArray

### DIFF
--- a/lib/flash.js
+++ b/lib/flash.js
@@ -2,8 +2,6 @@
  * Module dependencies.
  */
 var format = require('util').format;
-var isArray = require('util').isArray;
-
 
 /**
  * Expose `flash()` function on requests.
@@ -64,7 +62,7 @@ function _flash(type, msg) {
     if (arguments.length > 2 && format) {
       var args = Array.prototype.slice.call(arguments, 1);
       msg = format.apply(undefined, args);
-    } else if (isArray(msg)) {
+    } else if (Array.isArray(msg)) { // replaced isArray with Array.isArray
       msg.forEach(function(val){
         (msgs[type] = msgs[type] || []).push(val);
       });


### PR DESCRIPTION
Fixes the DEP0044 deprecation warning by replacing util.isArray with the native Array.isArray method.